### PR TITLE
Raspi setup and deployment

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -22,3 +22,25 @@ npm run lint
 
 ### Customize configuration
 See [Configuration Reference](https://cli.vuejs.org/config/).
+
+## Deployment on the pi
+
+### Setup basic tools and screen
+```
+sudo ./deploy/raspi_setup.sh
+````
+
+### Deploy the service
+```
+ sudo cp ./scanner.service /etc/systemd/system/
+ ```
+
+ ### Check Status of Service
+```
+sudo systemctl status scanner
+```
+
+### Restart Service
+```
+sudo systemctl restart scanner
+```

--- a/frontend/deploy/raspi_setup.sh
+++ b/frontend/deploy/raspi_setup.sh
@@ -1,0 +1,26 @@
+## Run this with sudo
+
+## Rotate the screen 90 degrees
+cp /boot/config.txt /boot/config.txt.bak
+sed -i '/dtoverlay/c\dtoverlay=tft35a:rotate=0' /boot/config.txt
+
+## Install node
+mkdir /opt/downloads
+##mkdir /usr/local/node-v12.7.0
+wget https://nodejs.org/dist/v12.7.0/node-v12.7.0-linux-armv7l.tar.gz -O /opt/downloads/node-v12.7.0.tar.gz
+tar -xzf /opt/downloads/node-v12.7.0.tar.gz -C /opt/downloads
+cp -R /opt/downloads/node-v12.7.0-linux-armv7l/* /usr/local/
+
+##
+npm install -g serve
+
+## Setup deploy location
+mkdir /usr/local/bin/scanner
+cd /usr/local/bin/scanner
+git init
+git remote add origin https://github.com/Scotsoo/ScannerSweep.git
+git fetch origin
+git checkout origin/frontend -- frontend
+cd frontend
+npm install
+

--- a/frontend/deploy/scanner.service
+++ b/frontend/deploy/scanner.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Scanner
+After=network-online.target
+Requires=network-online.target
+
+[Service]
+# ExecStart=serve -s dist
+ExecStart=/bin/bash start.sh
+Restart=always
+User=root
+# Note Debian/Ubuntu uses 'nogroup', RHEL/Fedora uses 'nobody'
+Group=root
+Environment=PATH=/usr/bin:/usr/local/bin
+Environment=NODE_ENV=development
+WorkingDirectory=/usr/local/bin/scanner/frontend/
+
+[Install]
+WantedBy=multi-user.target

--- a/frontend/deploy/start.sh
+++ b/frontend/deploy/start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd /usr/local/bin/scanner/frontend
+serve -l 8080 -s dist

--- a/frontend/raspi_setup.sh
+++ b/frontend/raspi_setup.sh
@@ -1,0 +1,25 @@
+## Run this with sudo
+
+## Rotate the screen 90 degrees
+cp /boot/config.txt /boot/config.txt.bak
+sed -i '/dtoverlay/c\dtoverlay=tft35a:rotate=0' /boot/config.txt
+
+## Install node
+mkdir /opt/downloads
+##mkdir /usr/local/node-v12.7.0
+wget https://nodejs.org/dist/v12.7.0/node-v12.7.0-linux-armv7l.tar.gz -O /opt/downloads/node-v12.7.0.tar.gz
+tar -xzf /opt/downloads/node-v12.7.0.tar.gz -C /opt/downloads
+cp -R /opt/downloads/node-v12.7.0-linux-armv7l/* /usr/local/
+
+## Add serve utility - used for starting the application
+npm install -g serve
+
+## Setup deploy location
+mkdir /usr/local/bin/scanner
+cd /usr/local/bin/scanner
+git init
+git remote add origin https://github.com/Scotsoo/ScannerSweep.git
+git fetch origin
+git checkout origin/frontend -- frontend
+cd frontend
+npm install


### PR DESCRIPTION
raspi_setup.sh    - basic utils. Should be run before the others.  Should deploy code in the right place.
scanner.service  - service file to daemonize the front-end
start.sh              - starts the service using the serve utility.